### PR TITLE
removed redundant variables

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -285,15 +285,12 @@ Router.prototype.use = function () {
   debug('use called %s', args);
   var name = typeof args[0] === 'string' || util.isRegExp(args[0]) ? args.shift() : '*';
   if (!args.length) throw new Error('we have the name, but need a handler');
-  var self = this;
   var fns = this.fns(name);
-  var i, arg, type;
-  for (i=0; i<args.length; i++) {
-    arg = args[i];
-    if (util.isArray(arg)) return self.use.apply(self, arg);
-    type = typeof arg;
-    if ('function' !== type) return;
-    fns[fns.length] = [self.index(), arg];
+  for (var i=0; i<args.length; i++) {
+    var arg = args[i];
+    if (util.isArray(arg)) return this.use.apply(this, arg);
+    if ('function' !== typeof arg) return;
+    fns.push([this.index(), arg]);
   }
   return this;
 };


### PR DESCRIPTION
removed `self` and `type` as redundant variables.

used hoisting for declaration of `arg` variable.

used only `push` operation instead 
1. compute length of array
2. find by index
3. assgin operation
